### PR TITLE
Set defaults

### DIFF
--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -1,3 +1,6 @@
+const defaultDrupalCore = '10.0.x';
+const defaultProfile = 'standard';
+
 document.addEventListener('DOMContentLoaded', function() {
     // Removed because we use only a specific main repo.
     // getDrupalPodRepo();
@@ -115,8 +118,8 @@ document.addEventListener('DOMContentLoaded', function() {
         const availablePatchesArray = getPatchesFromLinks(pageResults.allHrefs);
 
         populateSelectList('issue-branch', pageResults.issueBranches);
-        populateSelectList('core-version', drupalCoreVersionsArray);
-        populateSelectList('install-profile', drupalInstallProfiles, 'standard');
+        populateSelectList('core-version', drupalCoreVersionsArray, defaultDrupalCore);
+        populateSelectList('install-profile', drupalInstallProfiles, defaultProfile);
         populateSelectList('available-patches', availablePatchesArray);
 
         // Display form


### PR DESCRIPTION
This PR sets:
- default Drupal core ('10.0.x')
- default Profile ('standard')

Variables are set at the top of file to make it easier for mainters to update.

Fixes Drupal failure when no profile is set.
