### PR TITLE
Allows users to set DrupalPod repo

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -19,7 +19,6 @@
       </p>
     </div>
 
-    <div class="hidden"><span>DrupalPod repo:</span> <span id="devdrupalpod"></span></div>
     <div class="project-info">
       <span>Project name:</span> <span id="project-name"></span>
       <span>Project type:</span> <span id="project-type"></span>
@@ -46,6 +45,7 @@
     </div>
 
     <form class="form-selection hidden grid" id="form-selection" aria-live="polite">
+      <span>DrupalPod repo:</span> <span id="devdrupalpod"></span>
       <label for="core-version">Drupal core version:</label>
       <select name="core-version" id="core-version">
       </select>

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -3,7 +3,7 @@ const defaultProfile = 'standard';
 
 document.addEventListener('DOMContentLoaded', function() {
     // Removed because we use only a specific main repo.
-    // getDrupalPodRepo();
+    getDrupalPodRepo();
 
     // Check current URL to activate extension only on relevant pages
     chrome.tabs.query({active: true, currentWindow: true}, tabs => {
@@ -138,7 +138,7 @@ document.addEventListener('DOMContentLoaded', function() {
         // Build URL structure to open Gitpod
 
         const baseUrl = 'https://gitpod.io/#';
-        const envRepo = 'https://github.com/shaal/drupalpod';
+        const envRepo = document.getElementById('devdrupalpod').innerText;
         const projectName = 'DP_PROJECT_NAME=' + document.getElementById('project-name').innerText;
         const issueFork = 'DP_ISSUE_FORK=' + (document.getElementById('issue-fork').innerText === 'false' ? '' : document.getElementById('issue-fork').innerText);
         const issueBranch = 'DP_ISSUE_BRANCH=' + encodeURIComponent(getSelectValue('issue-branch'));


### PR DESCRIPTION
This PR re-enables the ability for users to set the DrupalPod repo.

This is due to current issues with shared prebuilds not working.

This option is set via the extensions options, NOT in the popup GUI.